### PR TITLE
eslint config, lint-staged config, Mantine 7 refactor,  init testing utilities

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,10 +32,6 @@
 		"prettier/prettier": [
 			"error"
 		],
-		"quotes": [
-			"error",
-			"single"
-		],
 		"semi": [
 			"error",
 			"never"

--- a/client/src/components/organisms/AuthForm/AuthForm.test.tsx
+++ b/client/src/components/organisms/AuthForm/AuthForm.test.tsx
@@ -1,50 +1,36 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import { renderWithProvidersUnauthenticated } from '@utils'
 import AuthForm from './AuthForm'
 
 describe('AuthForm', () => {
 	test('renders', async () => {
-		const onSubmit = () => null
-
-		render(<AuthForm onSubmit={onSubmit} />)
+		renderWithProvidersUnauthenticated(<AuthForm onSubmit={() => null} />)
 		expect(await screen.getByTestId('auth-form')).toBeInTheDocument()
 	})
 
-	test('displays a default message when a message is not provided', async () => {
-		const onSubmit = () => null
-
-		render(<AuthForm onSubmit={onSubmit} />)
+	test('displays a default messaging when messaging is not provided', async () => {
+		renderWithProvidersUnauthenticated(<AuthForm onSubmit={() => null} />)
 		expect(await screen.getByText('Welcome!')).toBeInTheDocument()
-	})
-
-	test('displays the provided message', async () => {
-		const MESSAGE = 'Hello!'
-		const onSubmit = () => null
-
-		render(<AuthForm onSubmit={onSubmit} message={MESSAGE} />)
-		expect(await screen.getByText(MESSAGE)).toBeInTheDocument()
-	})
-
-	test('displays the default "Submit" text when submit button text is not provided', async () => {
-		const onSubmit = () => null
-
-		render(<AuthForm onSubmit={onSubmit} />)
 		expect(await screen.getByText('Submit')).toBeInTheDocument()
 	})
 
-	test('displays the provided submit button text', async () => {
-		const SUBMIT = 'Click!'
-		const onSubmit = () => null
-
-		render(<AuthForm onSubmit={onSubmit} submitText={SUBMIT} />)
-		expect(await screen.getByText(SUBMIT)).toBeInTheDocument()
+	test('displays provided messaging', async () => {
+		const MESSAGE = 'Hello!'
+		const SUBMIT_TEXT = 'Click!'
+		renderWithProvidersUnauthenticated(
+			<AuthForm onSubmit={() => null} message={MESSAGE} submitText={SUBMIT_TEXT} />
+		)
+		expect(await screen.getByText(MESSAGE)).toBeInTheDocument()
+		expect(await screen.getByText(SUBMIT_TEXT)).toBeInTheDocument()
 	})
 
-	test('allows for a secondary action', async () => {
+	test('supports a secondary action', async () => {
 		const TEST_ID = 'testing'
-		const onSubmit = () => null
 		const secondaryAction = <span data-testid={TEST_ID}>Test</span>
 
-		render(<AuthForm onSubmit={onSubmit} SecondaryAction={secondaryAction} />)
+		renderWithProvidersUnauthenticated(
+			<AuthForm onSubmit={() => null} SecondaryAction={secondaryAction} />
+		)
 		expect(await screen.getByTestId(TEST_ID)).toBeInTheDocument()
 	})
 

--- a/client/src/components/organisms/AuthForm/AuthForm.tsx
+++ b/client/src/components/organisms/AuthForm/AuthForm.tsx
@@ -25,7 +25,7 @@ export default function AuthForm({
 	})
 
 	return (
-		<Box maw={300} mx="auto">
+		<Box w="20rem">
 			<Text component="h1" size="lg" ta="center">
 				{message ? message : 'Welcome!'}
 			</Text>
@@ -53,7 +53,7 @@ export default function AuthForm({
 					label="Remember me"
 					{...(form.getInputProps('remember'), { type: 'checkbox' })}
 				/>
-				<Group mt="xl">
+				<Group mt="xl" justify="center">
 					<Button type="submit" variant="light" w="100%">
 						{submitText ?? 'Submit'}
 					</Button>

--- a/client/src/components/pages/LogIn.tsx
+++ b/client/src/components/pages/LogIn.tsx
@@ -1,24 +1,59 @@
-import { useContext } from 'react'
-import { Link } from 'react-router-dom'
-import { Text } from '@mantine/core'
+import { useContext, useState } from 'react'
+import { Box, Text, UnstyledButton } from '@mantine/core'
 import { AuthContext } from '@contexts'
-import { SIGN_UP_PATH } from '@routes'
 import { AuthForm } from '@organisms'
 
+type AuthFlow = 'login' | 'signup'
+const LOGIN: AuthFlow = 'login'
+const SIGNUP: AuthFlow = 'signup'
+
 export default function LogIn() {
-	const { logIn } = useContext(AuthContext)
-	const message = <>Welcome Back!{<br />}Please log in to your account.</>
+	const { logIn, signUp } = useContext(AuthContext)
+	const [authFlow, setAuthFlow] = useState<AuthFlow>(LOGIN)
+	const messagingContent = {
+		[LOGIN]: {
+			action: logIn,
+			message: <>Welcome Back!{<br />}Please log in to your account.</>,
+			secondaryMessage: "Don't have an account?",
+			submitText: 'Log in'
+		},
+		[SIGNUP]: {
+			action: signUp,
+			message: <>Welcome!{<br />}Get ready to manage tasks!</>,
+			secondaryMessage: 'Already have an account?',
+			submitText: 'Sign up'
+		}
+	}
+	const content = messagingContent[authFlow]
+
+	const handleChangeAuthFlow = function handleChangeAuthFlow(): void {
+		;(authFlow === LOGIN && setAuthFlow(SIGNUP)) || (authFlow === SIGNUP && setAuthFlow(LOGIN))
+	}
+
+	// TODO: reset form on state change?
 
 	return (
-		<AuthForm
-			SecondaryAction={
-				<Text c="blue" component={Link} to={SIGN_UP_PATH} mx="auto">
-					Don't have an account?
-				</Text>
-			}
-			onSubmit={logIn}
-			message={message}
-			submitText="Log in"
-		/>
+		<Box
+			h="100%"
+			display="flex"
+			mx="auto"
+			style={{
+				alignItems: 'center',
+				justifyContent: 'center'
+			}}
+		>
+			<AuthForm
+				SecondaryAction={
+					<UnstyledButton>
+						<Text c="blue" component="span" onClick={handleChangeAuthFlow} mx="auto">
+							{content.secondaryMessage}
+						</Text>
+					</UnstyledButton>
+				}
+				onSubmit={content.action}
+				message={content.message}
+				submitText={content.submitText}
+			/>
+		</Box>
 	)
 }

--- a/client/src/shell/Header/Header.test.tsx
+++ b/client/src/shell/Header/Header.test.tsx
@@ -1,68 +1,53 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { BrowserRouter, MemoryRouter } from 'react-router-dom'
-import { AuthContext } from '@contexts'
+import { AppShell } from '@mantine/core'
+import { fireEvent, screen } from '@testing-library/react'
 import { LOG_IN_PATH } from '@routes'
-import Header from './Header'
-
-const renderAuthContext = function renderAuthContext(
-	children: React.ReactElement,
-	value: AuthContext
-) {
-	return render(<AuthContext.Provider value={value}>{children}</AuthContext.Provider>, {
-		wrapper: BrowserRouter
-	})
-}
-
-const unauthenticatedContext = {
-	logIn: () => null,
-	logOut: () => null,
-	signUp: () => null,
-	user: {
-		auth: false,
-		username: null
-	}
-}
-
-const authenticatedContext = {
-	logIn: () => null,
-	logOut: () => null,
-	signUp: () => null,
-	user: {
-		auth: true,
-		username: 'Zoinks Kaboom'
-	}
-}
+import { renderWithProvidersUnauthenticated, renderWithProvidersAuthenticated } from '@utils'
+import { Header } from './Header'
 
 describe('Shell header', () => {
 	test('renders', async () => {
-		render(<Header />, { wrapper: BrowserRouter })
+		renderWithProvidersUnauthenticated(
+			<AppShell>
+				<Header />
+			</AppShell>
+		)
 		expect(await screen.getByTestId('shell-header')).toBeInTheDocument()
 	})
 
 	test('displays "Log in" CTA when user is unauthenticated', async () => {
-		renderAuthContext(<Header />, unauthenticatedContext)
+		renderWithProvidersUnauthenticated(
+			<AppShell>
+				<Header />
+			</AppShell>
+		)
 		expect(await screen.getByText('Log in')).toBeInTheDocument()
 	})
 
 	test('doesn\'t display the "Log in" CTA when user is at auth route', async () => {
-		render(
-			<AuthContext.Provider value={unauthenticatedContext}>
-				<MemoryRouter initialEntries={[LOG_IN_PATH]}>
-					<Header />
-				</MemoryRouter>
-			</AuthContext.Provider>
+		renderWithProvidersUnauthenticated(
+			<AppShell>
+				<Header />
+			</AppShell>,
+			[LOG_IN_PATH]
 		)
-
 		expect(await screen.queryByText('Log in')).not.toBeInTheDocument()
 	})
 
 	test('displays nav menu when user is authenticated', async () => {
-		renderAuthContext(<Header />, authenticatedContext)
+		renderWithProvidersAuthenticated(
+			<AppShell>
+				<Header />
+			</AppShell>
+		)
 		expect(await screen.queryByTestId('shell-header-menu')).toBeInTheDocument()
 	})
 
 	test('nav menu dropdown includes "Log out" option', async () => {
-		renderAuthContext(<Header />, authenticatedContext)
+		renderWithProvidersAuthenticated(
+			<AppShell>
+				<Header />
+			</AppShell>
+		)
 		const menu = await screen.queryByTestId('shell-header-menu')
 		menu && fireEvent.click(menu)
 		expect(await screen.getByRole('menu')).toBeInTheDocument()

--- a/client/src/shell/Header/Header.tsx
+++ b/client/src/shell/Header/Header.tsx
@@ -1,15 +1,6 @@
 import { useContext } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import {
-	Avatar,
-	Button,
-	Container,
-	Header as AppHeader,
-	Menu,
-	UnstyledButton,
-	createStyles,
-	rem
-} from '@mantine/core'
+import { AppShell, Avatar, Button, Container, Menu, Text, UnstyledButton, rem } from '@mantine/core'
 import {
 	IconAtom2Filled,
 	IconDashboard,
@@ -20,47 +11,31 @@ import {
 import { AuthContext } from '@contexts'
 import { LOG_IN_PATH, SIGN_UP_PATH } from '@routes'
 
-const HEADER_HEIGHT = rem(60)
+export const HEADER_HEIGHT = rem(60)
 
-// TODO: theme
-const useStyles = createStyles(() => ({
-	root: {
-		position: 'relative',
-		zIndex: 1
-	},
-	header: {
-		display: 'flex',
-		justifyContent: 'space-between',
-		alignItems: 'center',
-		height: '100%'
-	},
-	link: {
-		color: 'inherit',
-		textDecoration: 'none'
-	},
-	logo: {
-		lineHeight: 0
-	}
-}))
-
-export default function Header() {
+export const Header = function Header() {
 	const location = useLocation()
 	const isAuthRoute = location?.pathname === LOG_IN_PATH || location?.pathname === SIGN_UP_PATH
-	const { classes } = useStyles()
 	const {
 		logOut,
 		user: { auth, username }
 	} = useContext(AuthContext)
 
 	return (
-		<AppHeader className={classes.root} data-testid="shell-header" height={HEADER_HEIGHT}>
-			<Container className={classes.header} size="xl">
-				<div className={classes.logo}>
-					<Link to="/">
-						{/* TODO: spinning animation while loading */}
-						<IconAtom2Filled size={36} />
-					</Link>
-				</div>
+		<AppShell.Header h={HEADER_HEIGHT} data-testid="shell-header" pos="relative">
+			<Container
+				display="flex"
+				h="100%"
+				size="xl"
+				style={{
+					alignItems: 'center',
+					justifyContent: 'space-between'
+				}}
+			>
+				<Text c="inherit" component={Link} lh="0" td="none" to="/">
+					{/* TODO: spinning animation while loading */}
+					<IconAtom2Filled size={36} />
+				</Text>
 				{!auth && !isAuthRoute && (
 					<span>
 						{/* TODO: loading icon when authenticating */}
@@ -96,21 +71,22 @@ export default function Header() {
 							</UnstyledButton>
 						</Menu.Target>
 						<Menu.Dropdown>
-							<Menu.Item icon={<IconSettings size={14} />}>
-								<Link className={classes.link} to="/settings">
+							<Menu.Item leftSection={<IconSettings size={14} />}>
+								<Text c="inherit" component={Link} td="none" to="/settings">
 									Account Settings
-								</Link>
+								</Text>
 							</Menu.Item>
-							<Menu.Item icon={<IconDashboard size={14} />}>
-								<Link className={classes.link} to="/dashboard">
+							<Menu.Item leftSection={<IconDashboard size={14} />}>
+								{/* Text component= Link */}
+								<Text c="inherit" component={Link} td="none" to="/dashboard">
 									Dashboard
-								</Link>
+								</Text>
 							</Menu.Item>
 							<Menu.Divider />
 							<Menu.Item
 								color="red"
 								component="button"
-								icon={<IconLogout size={14} />}
+								leftSection={<IconLogout size={14} />}
 								onClick={() => logOut(username)}
 							>
 								Log out
@@ -119,6 +95,6 @@ export default function Header() {
 					</Menu>
 				)}
 			</Container>
-		</AppHeader>
+		</AppShell.Header>
 	)
 }

--- a/client/src/shell/Header/index.tsx
+++ b/client/src/shell/Header/index.tsx
@@ -1,3 +1,1 @@
-import Header from './Header'
-
-export default Header
+export * from './Header'

--- a/client/src/shell/Shell/Shell.test.tsx
+++ b/client/src/shell/Shell/Shell.test.tsx
@@ -1,11 +1,10 @@
-import { render } from '@testing-library/react'
-import { BrowserRouter } from 'react-router-dom'
+import { screen } from '@testing-library/react'
+import { renderWithProvidersUnauthenticated } from '@utils'
 import Shell from './Shell'
 
 describe('Shell', () => {
 	test('renders', async () => {
-		const rendered = render(<Shell />, { wrapper: BrowserRouter })
-		const shell = await rendered.queryByTestId('shell')
-		expect(shell).toBeInTheDocument()
+		renderWithProvidersUnauthenticated(<Shell />)
+		expect(await screen.getByTestId('shell')).toBeInTheDocument()
 	})
 })

--- a/client/src/shell/Shell/Shell.tsx
+++ b/client/src/shell/Shell/Shell.tsx
@@ -1,15 +1,22 @@
 import { AppShell, Container, MantineProvider } from '@mantine/core'
+import '@mantine/core/styles.css'
 import { Outlet } from 'react-router-dom'
-import Header from '../Header'
+import { Header, HEADER_HEIGHT } from '../Header'
 import { AuthProvider } from '@contexts'
 
 export default function Shell() {
 	return (
 		// TODO: theme
-		<MantineProvider withGlobalStyles withNormalizeCSS>
+		<MantineProvider>
 			<AuthProvider>
-				<AppShell data-testid="shell" header={<Header />} padding="sm">
-					<Container size="xl">
+				<AppShell data-testid="shell" padding="sm">
+					<Header />
+					<Container
+						size="xl"
+						style={{
+							height: `calc(100vh - ${HEADER_HEIGHT})`
+						}}
+					>
 						<Outlet />
 					</Container>
 				</AppShell>

--- a/client/src/utils/index.tsx
+++ b/client/src/utils/index.tsx
@@ -1,4 +1,5 @@
 import StrictModeDroppable from './StrictModeDroppable'
 
-export { StrictModeDroppable }
+export * from './testing'
 export * from './validation'
+export { StrictModeDroppable }

--- a/client/src/utils/testing/index.tsx
+++ b/client/src/utils/testing/index.tsx
@@ -1,0 +1,1 @@
+export * from './renderWithProviders'

--- a/client/src/utils/testing/renderWithProviders.tsx
+++ b/client/src/utils/testing/renderWithProviders.tsx
@@ -1,0 +1,54 @@
+import { MantineProvider } from '@mantine/core'
+import { MemoryRouter } from 'react-router-dom'
+import { render } from '@testing-library/react'
+import { AuthContext } from '@contexts'
+
+const unauthenticatedContext: AuthContext = {
+	logIn: () => null,
+	logOut: () => null,
+	signUp: () => null,
+	user: {
+		auth: false,
+		username: null
+	}
+}
+
+const authenticatedContext: AuthContext = {
+	logIn: () => null,
+	logOut: () => null,
+	signUp: () => null,
+	user: {
+		auth: true,
+		username: 'Zoinks Kaboom'
+	}
+}
+
+const renderWithProviders = function renderWithProviders(
+	children: React.ReactElement,
+	authContext: AuthContext,
+	initialEntries?: string[]
+) {
+	return render(
+		<MantineProvider>
+			<AuthContext.Provider value={authContext}>
+				<MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+			</AuthContext.Provider>
+		</MantineProvider>
+	)
+}
+
+export const renderWithProvidersUnauthenticated = function renderWithProvidersUnauthenticated(
+	children: React.ReactElement,
+	initialEntries?: string[]
+) {
+	return renderWithProviders(children, unauthenticatedContext, initialEntries)
+}
+
+export const renderWithProvidersAuthenticated = function renderWithProvidersAuthenticated(
+	children: React.ReactElement,
+	initialEntries?: string[]
+) {
+	return renderWithProviders(children, authenticatedContext, initialEntries)
+}
+
+export default renderWithProviders

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"dependencies": {
 				"@fastify/auth": "^4.3.0",
 				"@fastify/static": "^6.10.2",
-				"@mantine/core": "^6.0.17",
-				"@mantine/form": "^6.0.17",
+				"@mantine/core": "^7.0.0",
+				"@mantine/form": "^7.0.0",
 				"@tabler/icons-react": "^2.27.0",
 				"ejs": "^3.1.9",
 				"fastify": "^4.21.0",
@@ -1843,130 +1843,10 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
-		"node_modules/@emotion/babel-plugin": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
-			"integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-module-imports": "^7.16.7",
-				"@babel/runtime": "^7.18.3",
-				"@emotion/hash": "^0.9.1",
-				"@emotion/memoize": "^0.8.1",
-				"@emotion/serialize": "^1.1.2",
-				"babel-plugin-macros": "^3.1.0",
-				"convert-source-map": "^1.5.0",
-				"escape-string-regexp": "^4.0.0",
-				"find-root": "^1.1.0",
-				"source-map": "^0.5.7",
-				"stylis": "4.2.0"
-			}
-		},
-		"node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@emotion/cache": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-			"integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
-			"peer": true,
-			"dependencies": {
-				"@emotion/memoize": "^0.8.1",
-				"@emotion/sheet": "^1.2.2",
-				"@emotion/utils": "^1.2.1",
-				"@emotion/weak-memoize": "^0.3.1",
-				"stylis": "4.2.0"
-			}
-		},
-		"node_modules/@emotion/hash": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-			"integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==",
-			"peer": true
-		},
-		"node_modules/@emotion/memoize": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-			"integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
-			"peer": true
-		},
-		"node_modules/@emotion/react": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
-			"integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
-			"peer": true,
-			"dependencies": {
-				"@babel/runtime": "^7.18.3",
-				"@emotion/babel-plugin": "^11.11.0",
-				"@emotion/cache": "^11.11.0",
-				"@emotion/serialize": "^1.1.2",
-				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-				"@emotion/utils": "^1.2.1",
-				"@emotion/weak-memoize": "^0.3.1",
-				"hoist-non-react-statics": "^3.3.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@emotion/serialize": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
-			"integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
-			"peer": true,
-			"dependencies": {
-				"@emotion/hash": "^0.9.1",
-				"@emotion/memoize": "^0.8.1",
-				"@emotion/unitless": "^0.8.1",
-				"@emotion/utils": "^1.2.1",
-				"csstype": "^3.0.2"
-			}
-		},
-		"node_modules/@emotion/sheet": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-			"integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==",
-			"peer": true
-		},
 		"node_modules/@emotion/unitless": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
 			"integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
-		},
-		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-			"integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-			"peer": true,
-			"peerDependencies": {
-				"react": ">=16.8.0"
-			}
-		},
-		"node_modules/@emotion/utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-			"integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==",
-			"peer": true
-		},
-		"node_modules/@emotion/weak-memoize": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
-			"integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==",
-			"peer": true
 		},
 		"node_modules/@esbuild/android-arm": {
 			"version": "0.17.19",
@@ -2520,25 +2400,29 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
-			"integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+			"integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+			"dependencies": {
+				"@floating-ui/utils": "^0.1.3"
+			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.5.tgz",
-			"integrity": "sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==",
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+			"integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
 			"dependencies": {
-				"@floating-ui/core": "^1.3.1"
+				"@floating-ui/core": "^1.4.2",
+				"@floating-ui/utils": "^0.1.3"
 			}
 		},
 		"node_modules/@floating-ui/react": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.19.2.tgz",
-			"integrity": "sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==",
+			"version": "0.24.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.8.tgz",
+			"integrity": "sha512-AuYeDoaR8jtUlUXtZ1IJ/6jtBkGnSpJXbGNzokBL87VDJ8opMq1Bgrc0szhK482ReQY6KZsMoZCVSb4xwalkBA==",
 			"dependencies": {
-				"@floating-ui/react-dom": "^1.3.0",
-				"aria-hidden": "^1.1.3",
+				"@floating-ui/react-dom": "^2.0.1",
+				"aria-hidden": "^1.2.3",
 				"tabbable": "^6.0.1"
 			},
 			"peerDependencies": {
@@ -2547,16 +2431,21 @@
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
-			"integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+			"integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
 			"dependencies": {
-				"@floating-ui/dom": "^1.2.1"
+				"@floating-ui/dom": "^1.5.1"
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0",
 				"react-dom": ">=16.8.0"
 			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
+			"integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA=="
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.8",
@@ -2832,69 +2721,53 @@
 			}
 		},
 		"node_modules/@mantine/core": {
-			"version": "6.0.17",
-			"resolved": "https://registry.npmjs.org/@mantine/core/-/core-6.0.17.tgz",
-			"integrity": "sha512-g3EDxcTJKisvEGTsGJPCGXiDumwr4O0nGNXwoGLnrg19nh3FAMfEIq18sJJLtRrBuarSbrvgMVYvKx1R6rTOWg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.0.0.tgz",
+			"integrity": "sha512-0F+AdATM6uzZyKD3YNR95EY4taYVpdnKIaEmjSNRqYnfHCK/4TcbG+srDDBXrXclyJpGg9I1TF1D5M1ePoBoNA==",
 			"dependencies": {
-				"@floating-ui/react": "^0.19.1",
-				"@mantine/styles": "6.0.17",
-				"@mantine/utils": "6.0.17",
-				"@radix-ui/react-scroll-area": "1.0.2",
-				"react-remove-scroll": "^2.5.5",
-				"react-textarea-autosize": "8.3.4"
+				"@floating-ui/react": "^0.24.8",
+				"clsx": "2.0.0",
+				"react-number-format": "^5.2.2",
+				"react-remove-scroll": "^2.5.6",
+				"react-textarea-autosize": "8.5.2",
+				"type-fest": "^3.13.1"
 			},
 			"peerDependencies": {
-				"@mantine/hooks": "6.0.17",
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
+				"@mantine/hooks": "7.0.0",
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
+			}
+		},
+		"node_modules/@mantine/core/node_modules/type-fest": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+			"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@mantine/form": {
-			"version": "6.0.17",
-			"resolved": "https://registry.npmjs.org/@mantine/form/-/form-6.0.17.tgz",
-			"integrity": "sha512-hrWlBukErklaFSvKfz4PCl3Cd7UgHf5Q/FyZPD+WvBDT0zZ5uMjatQpVs/HAfhFOA5O2DFKAcs654mLzmJJ6Wg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@mantine/form/-/form-7.0.0.tgz",
+			"integrity": "sha512-gFyk622WztFQM8Nh3t/gIjpdokd3hjxxFSgFxQb08Xa7y+1MbQ/D6QVuuGt0S9eCxUokTfBCdoyPtNRyHb3O9A==",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"klona": "^2.0.5"
 			},
 			"peerDependencies": {
-				"react": ">=16.8.0"
+				"react": "^18.2.0"
 			}
 		},
 		"node_modules/@mantine/hooks": {
-			"version": "6.0.17",
-			"resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-6.0.17.tgz",
-			"integrity": "sha512-7vf2w1NlzKlUynSuyI2DAIKoEOYKYC8k+tlSsk3BRdbzhbJAiWxcYzJy5seg5dFW1WIpKAZ0wiVdHXf/WRlRgg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.0.0.tgz",
+			"integrity": "sha512-HdZ6qE15OKNA3esbO72+mRqztMcdGphL/wl/ks8N7iAlSUu7sFtgZN+IU6MfJxGc/MEN3x5dEceWG6FgwOmHOw==",
 			"peer": true,
 			"peerDependencies": {
-				"react": ">=16.8.0"
-			}
-		},
-		"node_modules/@mantine/styles": {
-			"version": "6.0.17",
-			"resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-6.0.17.tgz",
-			"integrity": "sha512-utNwQJgKHguNS0iPyyeFRJy4nbt280XMbmfUf4GCxXlyl/mQxq+JoaKP/OmU7+8kfbtLS9kHeuBSghrC65Nt1g==",
-			"dependencies": {
-				"clsx": "1.1.1",
-				"csstype": "3.0.9"
-			},
-			"peerDependencies": {
-				"@emotion/react": ">=11.9.0",
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
-			}
-		},
-		"node_modules/@mantine/styles/node_modules/csstype": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-			"integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
-		},
-		"node_modules/@mantine/utils": {
-			"version": "6.0.17",
-			"resolved": "https://registry.npmjs.org/@mantine/utils/-/utils-6.0.17.tgz",
-			"integrity": "sha512-U6SWV/asYE6NhiHx4ltmVZdQR3HwGVqJxVulhOylMcV1tX/P1LMQUCbGV2Oe4O9jbX4/YW5B/CBb4BbEhENQFQ==",
-			"peerDependencies": {
-				"react": ">=16.8.0"
+				"react": "^18.2.0"
 			}
 		},
 		"node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -2946,137 +2819,6 @@
 			"optional": true,
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/@radix-ui/number": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.0.tgz",
-			"integrity": "sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			}
-		},
-		"node_modules/@radix-ui/primitive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
-			"integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			}
-		},
-		"node_modules/@radix-ui/react-compose-refs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
-			"integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0"
-			}
-		},
-		"node_modules/@radix-ui/react-context": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
-			"integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0"
-			}
-		},
-		"node_modules/@radix-ui/react-direction": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
-			"integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0"
-			}
-		},
-		"node_modules/@radix-ui/react-presence": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
-			"integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.0",
-				"@radix-ui/react-use-layout-effect": "1.0.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			}
-		},
-		"node_modules/@radix-ui/react-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
-			"integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-slot": "1.0.1"
-			},
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			}
-		},
-		"node_modules/@radix-ui/react-scroll-area": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.2.tgz",
-			"integrity": "sha512-k8VseTxI26kcKJaX0HPwkvlNBPTs56JRdYzcZ/vzrNUkDlvXBy8sMc7WvCpYzZkHgb+hd72VW9MqkqecGtuNgg==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/number": "1.0.0",
-				"@radix-ui/primitive": "1.0.0",
-				"@radix-ui/react-compose-refs": "1.0.0",
-				"@radix-ui/react-context": "1.0.0",
-				"@radix-ui/react-direction": "1.0.0",
-				"@radix-ui/react-presence": "1.0.0",
-				"@radix-ui/react-primitive": "1.0.1",
-				"@radix-ui/react-use-callback-ref": "1.0.0",
-				"@radix-ui/react-use-layout-effect": "1.0.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			}
-		},
-		"node_modules/@radix-ui/react-slot": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
-			"integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0"
-			}
-		},
-		"node_modules/@radix-ui/react-use-callback-ref": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
-			"integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0"
-			}
-		},
-		"node_modules/@radix-ui/react-use-layout-effect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
-			"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0"
 			}
 		},
 		"node_modules/@remix-run/router": {
@@ -3456,12 +3198,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.6.tgz",
 			"integrity": "sha512-q0RkvNgMweWWIvSMDiXhflGUKMdIxBo2M2tYM/0kEGDueQByFzK4KZAgu5YHGFNxziTlppNpTIBcqHQAxlfHdA==",
 			"dev": true
-		},
-		"node_modules/@types/parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-			"peer": true
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.5",
@@ -4200,21 +3936,6 @@
 				"fastq": "^1.6.1"
 			}
 		},
-		"node_modules/babel-plugin-macros": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-			"peer": true,
-			"dependencies": {
-				"@babel/runtime": "^7.12.5",
-				"cosmiconfig": "^7.0.0",
-				"resolve": "^1.19.0"
-			},
-			"engines": {
-				"node": ">=10",
-				"npm": ">=6"
-			}
-		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
@@ -4389,6 +4110,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -4595,9 +4317,9 @@
 			}
 		},
 		"node_modules/clsx": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-			"integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+			"integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -4794,31 +4516,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
-			}
-		},
-		"node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"peer": true,
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"peer": true,
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/create-require": {
@@ -5152,15 +4849,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/error-ex": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"peer": true,
-			"dependencies": {
-				"is-arrayish": "^0.2.1"
 			}
 		},
 		"node_modules/es-get-iterator": {
@@ -5845,12 +5533,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/find-root": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-			"peer": true
-		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -6390,6 +6072,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"dev": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -6492,12 +6175,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"peer": true
 		},
 		"node_modules/is-bigint": {
 			"version": "1.0.4",
@@ -7319,12 +6996,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/json-parse-even-better-errors": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"peer": true
-		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -7393,12 +7064,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/lines-and-columns": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"peer": true
 		},
 		"node_modules/lint-staged": {
 			"version": "13.2.3",
@@ -8220,29 +7885,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/parse-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"error-ex": "^1.3.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"lines-and-columns": "^1.1.6"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/parse5": {
@@ -8319,6 +7967,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -8668,6 +8317,18 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
 		},
+		"node_modules/react-number-format": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.3.1.tgz",
+			"integrity": "sha512-qpYcQLauIeEhCZUZY9jXZnnroOtdy3jYaS1zQ3M1Sr6r/KMOBEIGNIb7eKT19g2N1wbYgFgvDzs19hw5TrB8XQ==",
+			"dependencies": {
+				"prop-types": "^15.7.2"
+			},
+			"peerDependencies": {
+				"react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/react-redux": {
 			"version": "7.2.9",
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
@@ -8799,11 +8460,11 @@
 			}
 		},
 		"node_modules/react-textarea-autosize": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-			"integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.2.tgz",
+			"integrity": "sha512-uOkyjkEl0ByEK21eCJMHDGBAAd/BoFQBawYK5XItjAmCTeSbjxghd8qnt7nzsLYzidjnoObu6M26xts0YGKsGg==",
 			"dependencies": {
-				"@babel/runtime": "^7.10.2",
+				"@babel/runtime": "^7.20.13",
 				"use-composed-ref": "^1.3.0",
 				"use-latest": "^1.2.1"
 			},
@@ -8996,6 +8657,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -9403,15 +9065,6 @@
 			"integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0"
-			}
-		},
-		"node_modules/source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
 	"dependencies": {
 		"@fastify/auth": "^4.3.0",
 		"@fastify/static": "^6.10.2",
-		"@mantine/core": "^6.0.17",
-		"@mantine/form": "^6.0.17",
+		"@mantine/core": "^7.0.0",
+		"@mantine/form": "^7.0.0",
 		"@tabler/icons-react": "^2.27.0",
 		"ejs": "^3.1.9",
 		"fastify": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 	"lint-staged": {
 		"./client/src/**/*.{ts,tsx}": [
 			"prettier --write",
-			"eslint --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+			"eslint --report-unused-disable-directives --max-warnings 0",
 			"vitest related --run"
 		]
 	}


### PR DESCRIPTION
- Eslint config
    - Configure to not conflict with prettier on single quotes vs double quotes
- lint-staged config
    - lint-staged should only be linting staged files
 - Mantine 7 refactor
     - Refactor affected code to support API changes encountered while upgrading Mantine from 6 to 7
- Testing utilities
    - Create testing utilities directory, as well as application shell rendering utilities that provide  application shell with necessary providers, and unauthenticated and authenticated contexts